### PR TITLE
Using `ctrl-shift-s` on Mac - Added `.postcss-sorting.json` support

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Emil Kashkevich
+Copyright (c) 2015-2016 Emil Kashkevich
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ or open Atom and go to Preferences > Install and search for `postcss-sorting` pa
 
 In a CSS or PostCSS file, open the Command Palette (<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (OS X), <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (Windows/Linux)) and choose `PostCSS Sorting: Run`.
 
-Keyboard shortcuts: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd> (OS X), <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd> (Windows/Linux).
-
+Keyboard shortcut: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd>
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ $ apm install postcss-sorting
 ```
 or open Atom and go to Preferences > Install and search for `postcss-sorting` package.
 
+## Options
+
+You can select a preset from the ones bundled-in: default, csscomb, yandex and zen.
+
+Also a file named `.postcss-sorting.json` will be searched recursively, starting from the path of the file you are sorting. If found it will override the chosen preset configuration.
+
 ## Usage
 
 In a CSS or PostCSS file, open the Command Palette (<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (OS X), <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> (Windows/Linux)) and choose `PostCSS Sorting: Run`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or open Atom and go to Preferences > Install and search for `postcss-sorting` pa
 
 You can select a preset from the ones bundled-in: default, csscomb, yandex and zen.
 
-Also a file named `.postcss-sorting.json` will be searched recursively, starting from the path of the file you are sorting. If found it will override the chosen preset configuration.
+If you have a file named `.postcss-sorting.json` at the root of your project it will override the selected preset.
 
 ## Usage
 

--- a/keymaps/postcss-sorting.cson
+++ b/keymaps/postcss-sorting.cson
@@ -1,8 +1,2 @@
-'.platform-darwin atom-text-editor':
-  'ctrl-shift-s': 'postcss-sorting:run'
-
-'.platform-win32 atom-text-editor':
-  'ctrl-shift-s': 'postcss-sorting:run'
-
-'.platform-linux atom-text-editor':
+'atom-text-editor':
   'ctrl-shift-s': 'postcss-sorting:run'

--- a/keymaps/postcss-sorting.cson
+++ b/keymaps/postcss-sorting.cson
@@ -1,5 +1,5 @@
 '.platform-darwin atom-text-editor':
-  'cmd-shift-s': 'postcss-sorting:run'
+  'ctrl-shift-s': 'postcss-sorting:run'
 
 '.platform-win32 atom-text-editor':
   'ctrl-shift-s': 'postcss-sorting:run'

--- a/lib/postcss-sorting.coffee
+++ b/lib/postcss-sorting.coffee
@@ -1,7 +1,6 @@
 fs = require 'fs'
 path = require 'path'
 postcss = require 'postcss'
-rdf = require 'require-dot-file'
 sorting = require 'postcss-sorting'
 
 module.exports =
@@ -27,7 +26,14 @@ module.exports =
       content: if selection.length then selection else fs.readFileSync(editor.getPath())
       isSelection: selection.length > 0
 
-    options = rdf '.postcss-sorting.json', path.dirname ( src.filepath ) || null
+    options = null
+    optionsPath = atom.project.getDirectories()[0]?.resolve '.postcss-sorting.json'
+
+    if fs.existsSync optionsPath
+      try
+        options = JSON.parse(fs.readFileSync(optionsPath))
+      catch
+        options = null
 
     postcss([sorting ( options )]).process(src.content, preset).then((result) ->
       if src.isSelection

--- a/lib/postcss-sorting.coffee
+++ b/lib/postcss-sorting.coffee
@@ -1,5 +1,7 @@
 fs = require 'fs'
+path = require 'path'
 postcss = require 'postcss'
+rdf = require 'require-dot-file'
 sorting = require 'postcss-sorting'
 
 module.exports =
@@ -21,15 +23,17 @@ module.exports =
     selection = editor.getSelectedText()
 
     src =
-      path: editor.getPath()
+      filepath: editor.getPath()
       content: if selection.length then selection else fs.readFileSync(editor.getPath())
       isSelection: selection.length > 0
 
-    postcss([sorting]).process(src.content, preset).then((result) ->
+    options = rdf '.postcss-sorting.json', path.dirname ( src.filepath ) || null
+
+    postcss([sorting ( options )]).process(src.content, preset).then((result) ->
       if src.isSelection
         editor.insertText(result.css)
       else
-        fs.writeFileSync(src.path, result.css)
-      atom.notifications?.addSuccess("Successfully sorted using '#{preset}' preset.")
+        fs.writeFileSync(src.filepath, result.css)
+      atom.notifications?.addSuccess(if options then "Successfully sorted using custom '.postcss-sorting.json' file." else "Successfully sorted using '#{preset}' preset.")
     ).catch (error) ->
       atom.notifications?.addError("Sorting error: '#{error.reason}'.", {detail: error.message})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-sorting",
   "main": "./lib/postcss-sorting",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Atom editor plugin to sort CSS rules content with specified order.",
   "repository": "https://github.com/lysyi3m/atom-postcss-sorting",
   "license": "MIT",
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "postcss": "5.0.13",
-    "postcss-sorting": "1.1.0"
+    "postcss-sorting": "1.1.0",
+    "require-dot-file": "0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-sorting",
   "main": "./lib/postcss-sorting",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Atom editor plugin to sort CSS rules content with specified order.",
   "repository": "https://github.com/lysyi3m/atom-postcss-sorting",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-sorting",
   "main": "./lib/postcss-sorting",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Atom editor plugin to sort CSS rules content with specified order.",
   "repository": "https://github.com/lysyi3m/atom-postcss-sorting",
   "license": "MIT",
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "postcss": "5.0.13",
-    "postcss-sorting": "1.1.0",
-    "require-dot-file": "0.4.0"
+    "postcss-sorting": "1.1.0"
   }
 }


### PR DESCRIPTION
A fix for the issues #6 and #7
