### PR TITLE
added an option to check for config file to enable on save processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ If any of the following config files exist, they will override the selected pres
 
 Files can be processed "On Save" (not enabled by default).
 
+"On Save" can be disabled if no config file is present (not enabled by default).
+
 Notifications can also be disabled from the package settings.
 
 ## Usage
@@ -37,7 +39,7 @@ In a CSS or PostCSS file, open the Command Palette (<kbd>Cmd</kbd> + <kbd>Shift<
 
 Keyboard shortcut: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd>
 
-If you have an "On Save" option enabled just save a file. 
+If you have an "On Save" option enabled and "Check for config file" option disabled just save a file.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Added another option to check for config file to enable on save processing. This allows to conditionally enable on save depending on the project. 
To maintain backward-compatibility this option is disabled by default. 

This fixes https://github.com/lysyi3m/atom-postcss-sorting/issues/18